### PR TITLE
Update exponential retry snippet in the samples page

### DIFF
--- a/docs/en/api/partials/throttling.md
+++ b/docs/en/api/partials/throttling.md
@@ -3,7 +3,8 @@ To protect the availability of the Adobe back-end user identity systems, the Use
 - Maximum calls per a client: **{{ include.client }} requests per a minute**
 - Maximum calls for the application: **{{ include.global }} requests per a minute**
 
-When the client or global access limit is reached, further calls fail with HTTP error status **429 Too Many Requests**. The **Retry-After** header is included in the 429 response, and provides the minimum number of seconds to wait before retry:
+When the client or global access limit is reached, further calls fail with HTTP error status **429 Too Many Requests**. The **Retry-After** header is included in the 429 response, and provides the minimum amount of time that the client should wait until retrying. See [RFC 7231](https://tools.ietf.org/html/rfc7231#section-7.1.3) for full information.
+The following sample shows a 429 response with the Retry-After header detailing the number of seconds to wait before retry:
 
 ```
 ========================= RESPONSE =========================


### PR DESCRIPTION
Updated the code snippet in the samples page to take into account the `Retry-After` header. This snippet is also taken from, and refers to, the [umapi-client](https://github.com/adobe-apiplatform/umapi-client.py).