### PR TITLE
Add notice about April 2019 CC change

### DIFF
--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -84,3 +84,10 @@ a.api-ref-title, a.api-ref-subtitle {
 #directDescription {
 	display: none;
 }
+
+.isa_info {
+  margin: 10px 0px 24px 0px;
+  padding: 12px 12px 2px 12px;
+  color: #00529B;
+  background-color: #BDE5F8;
+}

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -9,6 +9,12 @@ lang: en
 
 Welcome to the documentation center for User Management APIs from Adobe.
 
+<div class="isa_info">
+<p>On April 2nd, 2019, Creative Cloud product names will remove the “CC”. For example, “Photoshop CC” will be renamed “Photoshop”.</p>
+<p>As a result, any applications directly accessing the User Management API which include logic <strong>dependent on the product name</strong> will need to be updated. If you have not included the product name in the code, then this will not impact your connection to the User Management API. If you use the User Sync Tool, you should see no impact.</p>
+<p>Note: the term “CC” included in the name of a Product Profile <em>will not change</em>. If you rely on the name of the “product admin group” (e.g., <code>_admin_&lt;product name&gt;</code>) you may be impacted and have to update your scripts.</p>
+<p>As a best practice, it is recommended to avoid any logic that expects fixed product names.</p>
+</div>
 
 [Getting Started with User Management](getstarted.md)
 


### PR DESCRIPTION
On April 2nd, 2019, Creative Cloud product names will remove the “CC”. For example, “Photoshop CC” will be renamed “Photoshop”. This adds a notice about expected impact.