### PR TITLE
add adminRoles to user schema

### DIFF
--- a/docs/en/api/getUser.md
+++ b/docs/en/api/getUser.md
@@ -140,6 +140,9 @@ __user:__  A _user_ object containing relevant properties. Properties that are n
   "message": "string",
   "result": "string",
   "user": {
+    "adminRoles": [
+      "string"
+    ],
     "country": "string",
     "domain": "string",
     "email": "string",


### PR DESCRIPTION
`adminRoles` is missing from the user schema on the getUsers page.