### PR TITLE
Announce groupId and pageSize changes

### DIFF
--- a/docs/en/api/group.md
+++ b/docs/en/api/group.md
@@ -127,6 +127,7 @@ The following fields are present for all group types:
   In addition, there are administrative groups for each user group and product profile. There are also developer groups for product profiles.
   These are named with a prefix and the group name. For example,
   `_admin_Marketing Group`, `_product_admin_Adobe Document Cloud for business` or `_developer_Marketing Group`.
+* __groupId:__ _long_; The unique identifier for the group.
 
 The following field is returned for groups of type `USER_ADMIN_GROUP`:
 
@@ -152,7 +153,8 @@ The following fields are returned for groups of type `PRODUCT_PROFILE`:
   "userGroupName": "string",
   "productProfileName": "string",
   "productName": "string",
-  "licenseQuota": "string"
+  "licenseQuota": "string",
+  "groupId": long
 }
 ```
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -12,6 +12,10 @@ Welcome to the documentation center for User Management APIs from Adobe.
 News:  
 <hr class="api-ref-rule">
 <div class="isa_info">
+<p>Starting March 10th 2020, new property <code>groupId</code> will be returned as part of the response for retrieving [groups and products](api/group.md). Clients are not impacted by this change.</p>
+<hr class="api-ref-rule">
+<p>Since February 11th 2020, the page size for APIs relating to the retrieval of users and/or groups has been increased from 200 to 400. No changes are required by existing clients.</p>
+<hr class="api-ref-rule">
 <p>Starting August 8th 2019, a change is applied to align with the multiple domains per directory model and tightening the security of the <strong>create</strong> and <strong>update</strong> APIs.</p>
 <p>As a result, any application using the <strong>create</strong> or <strong>update</strong> API statements using domains for which there's no claim in Admin Console, will start failing.</p>
 <hr class="api-ref-rule">


### PR DESCRIPTION
Updating index to announce following two changes:
- The return of `groupId` as part of response for `GET /v2/usermanagement/groups/{orgId}/{page}` API
- Page size has been increased for the following APIs from 200 to 400.
```
GET /v2/usermanagement/users/{orgId}/{page}
GET /v2/usermanagement/users/{orgId}/{page}/{groupName}
GET /v2/usermanagement/groups/{orgId}/{page}
```