### PR TITLE
Announce increase page size

### DIFF
--- a/docs/en/api/getUsersByGroup.md
+++ b/docs/en/api/getUsersByGroup.md
@@ -31,7 +31,7 @@ __Throttle Limits__: Maximum 5 requests per minute per a client. See [Throttling
 | groupName | path | true | The user group, product profile name or an administrative group. For an admin group, the name can be one of the fixed groups `_org_admin`, `_deployment_admin`, or `_support_admin`; or a group-specific admin group. These are identified with a prefix on the group name `_admin_groupName` , `_product_admin_productName`, `_developer_groupName`. If the group exists but the admin group does not, an empty list is returned. |
 | X-Api-Key | header | true | {% include_relative partials/apiKeyDescription.md %} |
 | Authorization | header | true | {% include_relative partials/authorizationDescription.md %} |
-| page | path | false | The 0-based index of the page number being requested. If greater than existing number of pages, returns the last page of users. Page size is 400 at time of writing. |
+| page | path | false | The 0-based index of the page number being requested. If greater than existing number of pages, returns the last page of users. The page size is variable with the current value returned in the X-Page-Size response header. |
 | content-type | header | false | {% include_relative partials/contentTypeDescription.md %} |
 | X-Request-Id | header | false | {% include_relative partials/requestIdDescription.md %} |
 | directOnly | query | false | {% include_relative partials/directOnlyDescription.md %} |

--- a/docs/en/api/getUsersREST.md
+++ b/docs/en/api/getUsersREST.md
@@ -33,7 +33,7 @@ __Throttle Limits__: Maximum 25 requests per minute per a client. See [Throttlin
 | orgId | path | true | {% include_relative partials/orgIdDescription.md %} |
 | X-Api-Key | header | true | {% include_relative partials/apiKeyDescription.md %} |
 | Authorization | header | true | {% include_relative partials/authorizationDescription.md %} |
-| page | query | false | The page number being requested. Page numbers greater than what exist will return the last page of users. |
+| page | query | false | The page number being requested. Page numbers greater than what exist will return the last page of users. The page size is variable with the current value returned in the X-Page-Size response header.|
 | content-type | header | false | {% include_relative partials/contentTypeDescription.md %} |
 | X-Request-Id | header | false | {% include_relative partials/requestIdDescription.md %} |
 | directOnly | query | false | {% include_relative partials/directOnlyDescription.md %} |

--- a/docs/en/api/getUsersWithPage.md
+++ b/docs/en/api/getUsersWithPage.md
@@ -28,7 +28,7 @@ __Throttle Limits__: Maximum 25 requests per minute per a client. See [Throttlin
 | :--- | :------ | :---: | :------ |
 | orgId | path | true | {% include_relative partials/orgIdDescription.md %} |
 | X-Api-Key | header | true | {% include_relative partials/apiKeyDescription.md %} |
-| page | path | true | The 0-based index of the page number being requested. If greater than last page number, returns the last page of users. Page size is 400 at time of writing. |
+| page | path | true | The 0-based index of the page number being requested. If greater than last page number, returns the last page of users. The page size is variable with the current value returned in the X-Page-Size response header. |
 | Authorization | header | true | {% include_relative partials/authorizationDescription.md %} |
 | content-type | header | false | {% include_relative partials/contentTypeDescription.md %} |
 | X-Request-Id | header | false | {% include_relative partials/requestIdDescription.md %} |

--- a/docs/en/api/group.md
+++ b/docs/en/api/group.md
@@ -28,7 +28,7 @@ __Throttle Limits__: Maximum 5 requests per minute per a client. See [Throttling
 | :--- | :------ | :---: | :------ |
 | orgId | path | true | {% include_relative partials/orgIdDescription.md %} |
 | X-Api-Key | header | true | {% include_relative partials/apiKeyDescription.md %} |
-| page | path | true | The 0-based index of the page number being requested. If greater than last page number, returns the last page of groups. |
+| page | path | true | The 0-based index of the page number being requested. If greater than last page number, returns the last page of groups. The page size is variable with the current value returned in the X-Page-Size response header. |
 | Authorization | header | true | {% include_relative partials/authorizationDescription.md %} |
 | content-type | header | false | {% include_relative partials/contentTypeDescription.md %} |
 | X-Request-Id | header | false | {% include_relative partials/requestIdDescription.md %} |

--- a/docs/en/api/group.md
+++ b/docs/en/api/group.md
@@ -28,7 +28,7 @@ __Throttle Limits__: Maximum 5 requests per minute per a client. See [Throttling
 | :--- | :------ | :---: | :------ |
 | orgId | path | true | {% include_relative partials/orgIdDescription.md %} |
 | X-Api-Key | header | true | {% include_relative partials/apiKeyDescription.md %} |
-| page | path | true | The 0-based index of the page number being requested. If greater than last page number, returns the last page of groups. Page size is 200 at time of writing. |
+| page | path | true | The 0-based index of the page number being requested. If greater than last page number, returns the last page of groups. |
 | Authorization | header | true | {% include_relative partials/authorizationDescription.md %} |
 | content-type | header | false | {% include_relative partials/contentTypeDescription.md %} |
 | X-Request-Id | header | false | {% include_relative partials/requestIdDescription.md %} |

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -12,9 +12,11 @@ Welcome to the documentation center for User Management APIs from Adobe.
 News:  
 <hr class="api-ref-rule">
 <div class="isa_info">
+<p>Since June 8th 2020, the page size for APIs relating to the retrieval of users has been increased from 400 to 1000. No changes are required by existing clients.</p>
+<hr class="api-ref-rule">
 <p>Starting March 10th 2020, new property <code>groupId</code> will be returned as part of the response for retrieving groups and products. Clients are not impacted by this change.</p>
 <hr class="api-ref-rule">
-<p>Since February 11th 2020, the page size for APIs relating to the retrieval of users and/or groups has been increased from 200 to 400. No changes are required by existing clients.</p>
+<p>Since February 11th 2020, the page size for APIs relating to the retrieval of groups has been increased from 200 to 400. No changes are required by existing clients.</p>
 <hr class="api-ref-rule">
 <p>Starting August 8th 2019, a change is applied to align with the multiple domains per directory model and tightening the security of the <strong>create</strong> and <strong>update</strong> APIs.</p>
 <p>As a result, any application using the <strong>create</strong> or <strong>update</strong> API statements using domains for which there's no claim in Admin Console, will start failing.</p>


### PR DESCRIPTION
Updating index to announce following change:

Page size has been increased for the following APIs from 400 to 1000.
```
GET /v2/usermanagement/users/{orgId}/{page}
GET /v2/usermanagement/users/{orgId}/{page}/{groupName}
```