### PR TITLE
Announce new throttling guidelines

### DIFF
--- a/docs/en/API_introduction.md
+++ b/docs/en/API_introduction.md
@@ -111,8 +111,6 @@ https://usermanagement.adobe.io/v2/usermanagement/{orgId}/product/{productId}/co
 
 To protect the availability of the Adobe back-end user identity systems, the User Management API imposes limits on client access to the data. Limits apply to the number of calls that an individual client can make within a time interval, and global limits apply to access by all clients within the time period.
 
-Our recommendation is to run the [User Sync Tool](https://adobe-apiplatform.github.io/user-sync.py/en/user-manual/deployment_best_practices.html) no more than once every 2 hours.  Running the calls more frequently can start a new session prior to the completion of the previous session, resulting in syncing delays. 
-
-Refer to the _Throttling_ section of each API to determine its limitations. When the access limit is reached, further calls fail with **429 Too Many Requests**.
+Our recommendation is to run the [User Sync Tool](https://adobe-apiplatform.github.io/user-sync.py/en/user-manual/deployment_best_practices.html) no more than once every 2 hours.  Refer to the _Throttling_ section of each API to determine its limitations. When the access limit is reached, further calls fail with **429 Too Many Requests**.
 
 If you are leveraging the [User Sync Tool](https://adobe-apiplatform.github.io/user-sync.py/en/user-manual/configuring_user_sync_tool.html), you can adjust your call frequency via Administrative access to the tool’s configuration file. 

--- a/docs/en/API_introduction.md
+++ b/docs/en/API_introduction.md
@@ -111,4 +111,8 @@ https://usermanagement.adobe.io/v2/usermanagement/{orgId}/product/{productId}/co
 
 To protect the availability of the Adobe back-end user identity systems, the User Management API imposes limits on client access to the data. Limits apply to the number of calls that an individual client can make within a time interval, and global limits apply to access by all clients within the time period.
 
+Our recommendation is to run the [User Sync Tool](https://adobe-apiplatform.github.io/user-sync.py/en/user-manual/deployment_best_practices.html) no more than once every 2 hours.  Running the calls more frequently can start a new session prior to the completion of the previous session, resulting in syncing delays. 
+
 Refer to the _Throttling_ section of each API to determine its limitations. When the access limit is reached, further calls fail with **429 Too Many Requests**.
+
+If you are leveraging the [User Sync Tool](https://adobe-apiplatform.github.io/user-sync.py/en/user-manual/configuring_user_sync_tool.html), you can adjust your call frequency via Administrative access to the tool’s configuration file. 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -10,8 +10,9 @@ lang: en
 Welcome to the documentation center for User Management APIs from Adobe.  
 
 News:  
-<hr class="api-ref-rule">
 <div class="isa_info">
+<p>Starting in February 2021, Adobe will add controls to the User Sync Tool scheduling feature to prevent running the tool more frequently than the recommended timing of no more than once every 2 hours. Running the calls more frequently can start a new session prior to the completion of the previous session, resulting in syncing delays.  When the access limit is reached, further calls fail with the error message ‘429 Too Many Requests’.</p>
+<hr class="api-ref-rule">
 <p>Since June 8th 2020, the page size for APIs relating to the retrieval of users has been increased from 400 to 1000. No changes are required by existing clients.</p>
 <hr class="api-ref-rule">
 <p>Starting March 10th 2020, new property <code>groupId</code> will be returned as part of the response for retrieving groups and products. Clients are not impacted by this change.</p>

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -11,7 +11,7 @@ Welcome to the documentation center for User Management APIs from Adobe.
 
 News:  
 <div class="isa_info">
-<p>Starting in February 2021, Adobe will add controls to the User Sync Tool scheduling feature to prevent running the tool more frequently than the recommended timing of no more than once every 2 hours. Running the calls more frequently can start a new session prior to the completion of the previous session, resulting in syncing delays.  When the access limit is reached, further calls fail with the error message ‘429 Too Many Requests’.</p>
+<p>Starting in February 2021, Adobe will add controls to the User Sync Tool scheduling feature to prevent running the tool more frequently than the recommended timing of no more than once every 2 hours. Running the calls more frequently can start a new session prior to the completion of the previous session, resulting in syncing delays.  Please refer to the _Throttling_ section of each API to determine its limitations. When the access limit is reached, further calls fail with the error message ‘429 Too Many Requests’.</p>
 <hr class="api-ref-rule">
 <p>Since June 8th 2020, the page size for APIs relating to the retrieval of users has been increased from 400 to 1000. No changes are required by existing clients.</p>
 <hr class="api-ref-rule">


### PR DESCRIPTION
UMAPI are enhancing their throttling engine so this PR updates the documentation to notify clients and provide some additional guidance on how to avoid being throttled.