### PR TITLE
Update ProductName returned for Single App Plans

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -11,6 +11,8 @@ Welcome to the documentation center for User Management APIs from Adobe.
 
 News:  
 <div class="isa_info">
+<p>Starting from 20th July 2021, there is an update when retrieving groups for ETLA customers with a Single App plan. When applicable, instead of returning _Single App_ in the <code>productName<code> field it will now be populated with the corresponding product name e.g. _Photoshop_.</p>
+<hr class="api-ref-rule">
 <p>Starting in February 2021, Adobe will add controls to check the running frequency of each User Sync Tool instance to prevent running the tool more frequently than the recommended timing of no more than once every 2 hours. Running the calls more frequently can start a new session prior to the completion of the previous session, resulting in syncing delays. When the access limit is reached, further calls fail with the error message ‘429 Too Many Requests’ and a Retry-After header containing the delay required before the next call can be made. Please refer to the _Throttling_ section of each API to determine its limitations and, if you are leveraging the User Sync Tool, please check their Deployment Best Practices section for scheduling recommendations.</p>
 <hr class="api-ref-rule">
 <p>Since June 8th 2020, the page size for APIs relating to the retrieval of users has been increased from 400 to 1000. No changes are required by existing clients.</p>

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -12,6 +12,10 @@ Welcome to the documentation center for User Management APIs from Adobe.
 News:  
 <div class="isa_info">
 <p>Starting from 20th July 2021, there is an update when retrieving groups for ETLA customers with a Single App plan. When applicable, instead of returning _Single App_ in the <code>productName</code> field it will now be populated with the corresponding product name e.g. _Photoshop_.</p>
+<p>As a result, any application directly accessing the User Management API which includes logic <strong>dependent on the _Single App_ product name</strong> will need to be updated. If you have not included the product name in the code, then this will not impact your connection to the User Management API. If you use the User Sync Tool, you should see no impact.</p>
+<p>As a best practice, it is recommended to avoid any logic that expects fixed product names.</p>
+<hr class="api-ref-rule">
+<p>Since 27th April 2021, the page size for APIs relating to the retrieval of users has been increased from 1000 to 2000. No changes are required by existing clients.</p>
 <hr class="api-ref-rule">
 <p>Starting in February 2021, Adobe will add controls to check the running frequency of each User Sync Tool instance to prevent running the tool more frequently than the recommended timing of no more than once every 2 hours. Running the calls more frequently can start a new session prior to the completion of the previous session, resulting in syncing delays. When the access limit is reached, further calls fail with the error message ‘429 Too Many Requests’ and a Retry-After header containing the delay required before the next call can be made. Please refer to the _Throttling_ section of each API to determine its limitations and, if you are leveraging the User Sync Tool, please check their Deployment Best Practices section for scheduling recommendations.</p>
 <hr class="api-ref-rule">

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -11,7 +11,7 @@ Welcome to the documentation center for User Management APIs from Adobe.
 
 News:  
 <div class="isa_info">
-<p>Starting from 20th July 2021, there is an update when retrieving groups for ETLA customers with a Single App plan. When applicable, instead of returning _Single App_ in the <code>productName<code> field it will now be populated with the corresponding product name e.g. _Photoshop_.</p>
+<p>Starting from 20th July 2021, there is an update when retrieving groups for ETLA customers with a Single App plan. When applicable, instead of returning _Single App_ in the <code>productName</code> field it will now be populated with the corresponding product name e.g. _Photoshop_.</p>
 <hr class="api-ref-rule">
 <p>Starting in February 2021, Adobe will add controls to check the running frequency of each User Sync Tool instance to prevent running the tool more frequently than the recommended timing of no more than once every 2 hours. Running the calls more frequently can start a new session prior to the completion of the previous session, resulting in syncing delays. When the access limit is reached, further calls fail with the error message ‘429 Too Many Requests’ and a Retry-After header containing the delay required before the next call can be made. Please refer to the _Throttling_ section of each API to determine its limitations and, if you are leveraging the User Sync Tool, please check their Deployment Best Practices section for scheduling recommendations.</p>
 <hr class="api-ref-rule">


### PR DESCRIPTION
Currently, when a client fetches a list of [groups](https://adobe-apiplatform.github.io/umapi-documentation/en/api/group.html) when they have a Single App Plan, they are returned with:
```
{
    "lastPage": true,
    "result": "success",
    "groups": [
        {
            "groupId": 149300376,
            "groupName": "_org_admin",
            "type": "SYSADMIN_GROUP",
            "memberCount": 2
        },
        {
            "groupId": 295047964,
            "groupName": "Illustrator on Ipad: TestIllustratorOnIpad",
            "type": "PRODUCT_PROFILE",
            "adminGroupName": "_admin_Illustrator on Ipad: TestIllustratorOnIpad",
            "memberCount": 1,
            "productName": "Single App",
            "licenseQuota": "5"
        },
        {
            "groupId": 295054807,
            "groupName": "Photoshop: Test Photoshop Profile",
            "type": "PRODUCT_PROFILE",
            "adminGroupName": "_admin_Photoshop: Test Photoshop Profile",
            "memberCount": 1,
            "productName": "Single App",
            "licenseQuota": "5"
        }
    ]
}
```
Both profiles have the `productName` populated as _Single App_ but they correspond to different products. On 20th July 2021 we will release an update to populate this field with the correct product name:
```
{
    "lastPage": true,
    "result": "success",
    "groups": [
        {
            "groupId": 149300376,
            "groupName": "_org_admin",
            "type": "SYSADMIN_GROUP",
            "memberCount": 2
        },
        {
            "groupId": 295047964,
            "groupName": "Illustrator on Ipad: TestIllustratorOnIpad",
            "type": "PRODUCT_PROFILE",
            "adminGroupName": "_admin_Illustrator on Ipad: TestIllustratorOnIpad",
            "memberCount": 1,
            "productName": "Illustrator on Ipad",
            "licenseQuota": "5"
        },
        {
            "groupId": 295054807,
            "groupName": "Photoshop: Test Photoshop Profile",
            "type": "PRODUCT_PROFILE",
            "adminGroupName": "_admin_Photoshop: Test Photoshop Profile",
            "memberCount": 1,
            "productName": "Photoshop",
            "licenseQuota": "5"
        }
    ]
}
```