### PR TITLE
Add notice about August 2022 DC change

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016-2020 Adobe Systems Incorporated.  All rights reserved.
+Copyright (c) 2016-2022 Adobe Systems Incorporated.  All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of these documentation files (the "Documentation"), to deal

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This documentation is open source, maintained by Adobe, and distributed under the terms
 of the OSI-approved MIT license.  See the LICENSE file for details.
 
-Copyright (c) 2016-2020 Adobe Systems Incorporated.
+Copyright (c) 2016-2022 Adobe Systems Incorporated.
 
 https://www.adobe.io/products/usermanagement/docs/gettingstarted.html
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -11,6 +11,11 @@ Welcome to the documentation center for User Management APIs from Adobe.
 
 News:  
 <div class="isa_info">
+<p>On August 8th, 2022, Document Cloud product names will remove the "DC" suffix. For example, "Acrobat Pro DC" will be renamed “Acrobat Pro".</p>
+<p>As a result, any application directly accessing the User Management API which include logic <strong>dependent on the product name</strong> will need to be updated. If you have not included the product name in the code, then this will not impact your connection to the User Management API. If you use the User Sync Tool, you should see no impact.</p>
+<p>Note: the term "DC" included in the name of a Product Profile <em>will not change</em>. If you rely on the name of the “product admin group” (e.g., <code>_admin_&lt;product name&gt;</code>) you may be impacted and have to update your scripts.</p>
+<p>As a best practice, it is recommended to avoid any logic that expects fixed product names.</p>
+<hr class="api-ref-rule">
 <p>Starting from 20th July 2021, there is an update when retrieving groups for ETLA customers with a Single App plan. When applicable, instead of returning _Single App_ in the <code>productName</code> field it will now be populated with the corresponding product name e.g. _Photoshop_.</p>
 <p>As a result, any application directly accessing the User Management API which includes logic <strong>dependent on the _Single App_ product name</strong> will need to be updated. If you have not included the product name in the code, then this will not impact your connection to the User Management API. If you use the User Sync Tool, you should see no impact.</p>
 <p>As a best practice, it is recommended to avoid any logic that expects fixed product names.</p>


### PR DESCRIPTION
The "DC" suffix will be removed from Document Cloud product names from 8 August 2022.