### PR TITLE
Update GET /user documentation to identify total count discrepancies

### DIFF
--- a/docs/en/api/getUsersWithPage.md
+++ b/docs/en/api/getUsersWithPage.md
@@ -13,7 +13,7 @@ lang: en
 GET /v2/usermanagement/users/{orgId}/{page}
 ```
 
-Retrieve a paged list of all users in your organization along with information about them. The number of users returned in each call is subject to change, currently the limit is max 400 entries/page. You can make multiple paginated calls to retrieve the full list of users. The `domain` query parameter filters the results to only return users within a specified domain.
+Retrieve a paged list of all users in your organization along with information about them. The number of users returned in each call is subject to change, currently the limit is max 2000 entries/page. You can make multiple paginated calls to retrieve the full list of users. The `domain` query parameter filters the results to only return users within a specified domain.
 
 __Throttle Limits__: Maximum 25 requests per minute per a client. See [Throttling Limits](#getUsersWithPageThrottle) for full details.
 

--- a/docs/en/api/partials/pagedResponseHeaders.md
+++ b/docs/en/api/partials/pagedResponseHeaders.md
@@ -1,6 +1,6 @@
 | Header |  Description |
 | :------ | :------------- |
-| X-Total-Count | The total count of {{include.object}} being returned across all pages. | 
+| X-Total-Count | The total count of {{include.object}}. Please note that the total number of {{include.object}} objects may not be returned in the response body. For example when fetching users, Technical Accounts will be excluded from the results. | 
 | X-Page-Count | The maximum number of pages that could be fetched with the criteria specified. |   
 | X-Current-Page | The integer value of the page being returned. |
 | X-Page-Size | The number of entries in the page being returned. |


### PR DESCRIPTION
The `X-Total-Count` header will return the total number of users in the org or group that is being queried. However UMAPI excludes technical accounts from the response body so the count of users returned may not equal the X-Total-Count header.