### PR TITLE
Remove [UM_Server]/{orgId}/user-groups/* APIs from the documentation

### DIFF
--- a/docs/en/api/QueryUserGroups.md
+++ b/docs/en/api/QueryUserGroups.md
@@ -1,22 +1,22 @@
 ---
 layout: default
-nav_link: Get User Group Users and Admins
+nav_link: Get User Group Users
 nav_order: 463
 nav_level: 4
 lang: en
-title: Get User Group Users and Admins
+title: Get User Group Users
 ---
-# <a name="queryUserGroups" class="api-ref-title">Get User-group Users and Admins</a>
+# <a name="queryUserGroups" class="api-ref-title">Get User-group Users</a>
 
 **DEPRECATED:** These APIs have been deprecated. An exact date for removal will be confirmed before the end of 2017 but you should look to update your scripts as soon as possible.
 
 <hr class="api-ref-rule">
 
-User group information defined for your organization in the [Admin Console](https://adminconsole.adobe.com/enterprise/) is available through the **{orgId}/user-groups** resource.
+User group information defined for your organization in the [Admin Console](https://adminconsole.adobe.com/enterprise/) is available through the **{orgId}/user-groups** resource.
 
 * [Get a paged list of user groups defined for your organization](getUserGroups.md)
 * [Get information for a specific user group](getUserGroup.md)
-* [Get a paged list of users or admins users who belong to a specific user group](#users)
+* [Get a paged list of users who belong to a specific user group](#users)
 
 ### Notation
 
@@ -37,11 +37,10 @@ You must include these headers in all requests:
 
 ## <a name="users" class="api-ref-subtitle">List Users in a User Group</a>
 
-A GET request to the **/users** or **/admins** endpoint under a specific user group retrieves a paged list of users who belong to the group, or of users with the administrative role for the group.
+A GET request to the **/users** endpoint under a specific user group retrieves a paged list of users who belong to the group.
 
 ```
 GET [UM_Server]/{orgId}/user-groups/{groupId}/users[?page={n}]
-GET [UM_Server]/{orgId}/user-groups/{groupId}/admins[?page={n}]
 ```
 
 * **{orgId}** : Required. The unique ID of your organization.
@@ -62,14 +61,13 @@ A successful request returns a response with **HTTP status 200**. The response b
     "status": "active",
     "userType": "federatedID"
    },
-  {
+   {
     "email": "anksharm@adobe.com",
     "firstName": "ankush",
     "lastName": "kumar",
     "countryCode": "IN",
     "status": "active",
     "userType": "adobeID"
-   },
-   ...
+   }
   ]
 ```

--- a/docs/en/api/usergroup.md
+++ b/docs/en/api/usergroup.md
@@ -8,21 +8,10 @@ lang: en
 ---
 # <a name="userGroups" class="api-ref-title">User Group APIs</a>
 
-**DEPRECATED:** These APIs have been deprecated. An exact date for removal will be confirmed before the end of 2017 but you should look to update your scripts as soon as possible.
-
-```
-POST /v2/usermanagement/{orgId}/user-groups
-PUT /v2/usermanagement/{orgId}/user-groups/{groupId}
-DELETE /v2/usermanagement/{orgId}/user-groups/{groupId}
-```
-
-<hr class="api-ref-rule">
 
 You cannot create either user groups or product profiles through the API. You must create them in the [Admin Console](https://adminconsole.adobe.com/enterprise/). You can then use the User Management API to manage product access for users by adding and removing users to and from your existing user groups and product profiles.
 
-You can use the a POST request to the [`action` resource](ActionsRef.md) for your organization to manage user group memberships, and to manage administrative rights in user groups. The _commands_ in the body of your POST request specify _action steps_ to take for a given _user_.
+You can use a POST request to the [`action` resource](ActionsRef.md) for your organization to manage user group memberships, and to manage administrative rights in user groups. The _commands_ in the body of your POST request specify _action steps_ to take for a given _user_.
 
 * [add](usergroupActionCommands.md#addRemove) Add a user to a specified _usergroup_
 * [remove](usergroupActionCommands.md#addRemove) Remove a user from a specified _usergroup_
-
-<hr class="api-ref-rule">


### PR DESCRIPTION
These APIs has been deprecated since 2017. 
This PR removes the documentation related to the following APIs:
```
POST /v2/usermanagement/{orgId}/user-groups
PUT /v2/usermanagement/{orgId}/user-groups/{groupId}
DELETE /v2/usermanagement/{orgId}/user-groups/{groupId}
GET [UM_Server]/{orgId}/user-groups/{groupId}/admins[?page={n}]
```