### PR TITLE
Remove GET /products/{productId} API

### DIFF
--- a/docs/en/api/QueryProducts.md
+++ b/docs/en/api/QueryProducts.md
@@ -19,11 +19,6 @@ Product information defined for your organization in the [Admin Console](https:/
 ```
 GET /v2/usermanagement/{orgId}/products/
 ```
-* Retrieve information for an individual product by its unique ID.
-
-```
-GET /v2/usermanagement/{orgId}/products/{productId}
-```
 ### Request headers
 
 You must include these headers in all requests:
@@ -58,7 +53,7 @@ A successful request returns a response with **HTTP status 200**. The response b
    "configurationCount": 2,
    "licenseQuota": 10
   },
- {
+  {
    "id": "YYYY-DEF123456789ABCDE",
    "code": "APAP",
    "name": "Adobe Document Cloud for business",
@@ -66,7 +61,7 @@ A successful request returns a response with **HTTP status 200**. The response b
    "configurationCount": 1,
    "licenseQuota": 20
   },
- {
+  {
    "id": "ZZZZ-GHI123456789ABCDE",
    "code": "CCSV",
    "name": "All Apps plan",
@@ -85,35 +80,3 @@ A failed request can result in a response with one of these HTTP status values, 
 * **404 Not Found** : productId was not found.
 
 _Note that server errors can occur that require exponential back-off on retry._
-
-## Get Product Information
-
-A GET request to the **{orgId}/products/{productId}** resource retrieves the product information for an individual Adobe product. The body of the response contains the product information in JSON format.
-
-```
-GET [UM_Server]/{orgId}/products/{productId}
-```
-
-* **{orgId}** : Required. Your organization ID.
-* **{productId}** : Required. The unique ID of the product.
-
-### Responses
-
-A successful request returns the requested data with **HTTP status 200**. The response body contains the requested product data in JSON format.
-
-```json
-{
- [
-  {
-    "id": "XXXX-123456789ABCD",
-    "code": "SUPPORT",
-    "name": "Support",
-    "userCount": 1,
-    "configurationCount": 2,
-    "licenseQuota": 10
-   }
-  ]
- }
-```
-
-


### PR DESCRIPTION
This API has been deprecated since 2017. This PR is removing references to the following API from the documentation:
```
GET /v2/usermanagement/{orgId}/products/{productId}
```