### PR TITLE
Update getUsersByGroup.md

### DIFF
--- a/docs/en/api/getUsersByGroup.md
+++ b/docs/en/api/getUsersByGroup.md
@@ -224,4 +224,4 @@ curl -X GET https://usermanagement.adobe.io/v2/usermanagement/users/12345@AdobeO
 
 ## <a name="getUsersByGroupThrottle" class="api-ref-subtitle">Throttling Limits</a>
 
-{% include_relative partials/throttling.md client=25 global=100 %}
+{% include_relative partials/throttling.md client=5 global=100 %}


### PR DESCRIPTION
The top reference to the throttling limit was changed to 5 but the bottom reference for the client throttling limit within the Throttling section remained at 25.