### PR TITLE
_org_admin statemnet

### DIFF
--- a/docs/en/api/ActionsCmds.md
+++ b/docs/en/api/ActionsCmds.md
@@ -379,7 +379,7 @@ Add or remove membership in administrative groups to control administrative righ
  * Support Administrators: `_support_admin` 
  * Deployment Administrators: `_deployment_admin` 
 
- Please note that you cannot assign or remove the administrative role `_org_admin` using the User Management API.
+ Please note that you cannot assign or remove the administrative role `_org_admin` using the Group Action Commands.
 
 In addition, there are administrative groups for each user group and product profile. 
   * An administrative group for a product is named with the prefix `_product_admin_` and the product name. For example, `_product_admin_Photoshop`. You should avoid any logic that expects fixed group names as these are liable to change without notice.  


### PR DESCRIPTION
because it's still possible to remove the org admin role via {remove: all} or removeFromOrg