### PR TITLE
Introduce new tags property to the user object response

### DIFF
--- a/docs/en/api/getUser.md
+++ b/docs/en/api/getUser.md
@@ -65,6 +65,9 @@ The response body contains the requested user data in JSON format including any 
     "type": "adobeID",
     "groups": [
       "_org_admin"
+    ],
+    "tags": [
+      "edu_student"
     ]
   }
 }
@@ -117,21 +120,7 @@ __message:__ _string_ An error message, returned only if initial validation of t
 ```
 
 __user:__  A _user_ object containing relevant properties. Properties that are not populated are not returned in the response. Some properties are not applicable for particular account types.
-
-* __country:__ _string_; A valid ISO 2-character country code.
-* __domain:__ _string_; The user's domain.
-* __email:__ _string_; The user's email address.
-* __firstname:__ _string_; The user's first name.
-* __groups:__ _string[]_; The list of groups that the user is a current member of, including user groups, product profiles, product admin groups, and group-specific admin groups. Administrative groups are named with a prefix and the group name. For example, `_product_admin_Photoshop`, `_admin_DesignTools`, or `_developer_Marketing`. You should avoid any logic that expects fixed group names as these are liable to change without notice. Organization-wide admin groups are:
-  * `_org_admin`: The user is a [System Administrator](glossary.md#orgAdmin).
-  * `_deployment_admin`: The user is a [Deployment Administrator](glossary.md#deployment).
-  * `_support_admin`: The user is a [Support Administator](glossary.md#supportAdmin).
-* __id:__ _string_; The user's unique identifier.
-* __lastname:__ _string_; The user's last name.
-{% include_relative partials/statusDescription.md %}
-* __type:__ _string_; The user type, one of: `{ "adobeID", "enterpriseID", "federatedID", "unknown" }`;  See [Identity Types](glossary.md#identity) for more information.
-* __username:__ _string_; The user's username (applicable for [Enterprise](glossary.md#enterpriseId) and [Federated](glossary.md#federatedId) users). For most [AdobeID](glossary.md#adobeId) users, this value is the same as the email address.
-* **adminRoles:** _string[]_; Deprecated. Administrative roles are reflected in group memberships, returned in the `groups` field.
+{% include_relative partials/userSchemaDescription.md %}
 
 ### Schema Model
 
@@ -151,7 +140,10 @@ __user:__  A _user_ object containing relevant properties. Properties that are n
     "lastname": "string",
     "status": "string",
     "type": "string",
-    "username": "string"
+    "username": "string",
+    "tags": [
+      "string"
+    ]
   }
 }
 ```

--- a/docs/en/api/getUsersByGroup.md
+++ b/docs/en/api/getUsersByGroup.md
@@ -78,7 +78,10 @@ A successful request returns a response body with the requested user data in JSO
             "username": "john",
             "domain": "example.com",
             "country": "US",
-            "type": "federatedID"
+            "type": "federatedID",
+            "tags": [
+                "edu_student"
+            ]
         },
         {
             "email": "jane@example.com",
@@ -152,20 +155,7 @@ __message:__ _string_ An error message, returned only if initial validation of t
 ```
 
 __users:__  Contains a list of _User_ objects. Properties that are not populated are not returned in the response. Some properties are not applicable for particular account types.
-* __country:__ _string_; A valid ISO 2-character country code.
-* __domain:__ _string_; The user's domain.
-* __email:__ _string_; The user's email address.
-* __firstname:__ _string_; The user's first name.
-* __groups:__ _string[]_; The list of groups in which the user is a current member, including, user groups, product profiles, product admin groups, and group-specific admin groups. Administrative groups are named with a prefix and the group name. For example, `_product_admin_Photoshop`, `_admin_DesignTools`, or `_developer_Marketing`. You should avoid any logic that expects fixed group names as these are liable to change without notice. Organization-wide admin groups are:
-  * `_org_admin`: The user is a [System Administrator](glossary.md#orgAdmin).
-  * `_deployment_admin`: The user is a [Deployment Administrator](glossary.md#deployment).
-  * `_support_admin`: The user is a [Support Administator](glossary.md#supportAdmin).
-* __id:__ _string_; The user's unique identifier.
-* __lastname:__ _string_; The user's last name.
-{% include_relative partials/statusDescription.md %}
-* __type:__ _string_, The user type, one of: `{ "adobeID", "enterpriseID", "federatedID", "unknown" }`. See [Identity Types](glossary.md#identity) for more information.
-* __username:__ _string_; The user's username (applicable for [Enterprise](glossary.md#enterpriseId) and [Federated](glossary.md#federatedId) users). For most Adobe ID users, this value is the same as the email address.
-* **adminRoles:** _string[]_; Deprecated. Administrative roles are reflected in group memberships, returned in the `groups` field.
+{% include_relative partials/userSchemaDescription.md %}
 
 ### Schema Model
 
@@ -188,7 +178,10 @@ __users:__  Contains a list of _User_ objects. Properties that are not populated
       "lastname": "string",
       "status": "string",
       "type": "string",
-      "username": "string"
+      "username": "string",
+      "tags": [
+          "string"
+      ]
     }
   ]
 }

--- a/docs/en/api/getUsersWithPage.md
+++ b/docs/en/api/getUsersWithPage.md
@@ -72,7 +72,10 @@ A successful request returns a response body with the requested user data in JSO
             "username": "psmith",
             "domain": "example.com",
             "country": "US",
-            "type": "federatedID"
+            "type": "federatedID",
+            "tags": [
+                "edu_student"
+            ]
         },
         {
             "email": "jane@example.com",
@@ -149,20 +152,7 @@ __message:__ _string_ An error message, returned only if initial validation of t
 ```
 
 __users:__  Contains a list of _User_ objects. Properties that are not populated are not returned in the response. Some properties are not applicable for particular account types.
-* __country:__ _string_; A valid ISO 2-character country code.
-* __domain:__ _string_; The user's domain.
-* __email:__ _string_; The user's email address.
-* __firstname:__ _string_; The user's first name.
-* __groups:__ _string[]_; The list of groups that the user is a current member of, including user groups, product profiles, product-specific admin groups, and group-specific admin groups. Administrative groups are named with a prefix and the group name. For example, `_admin_DesignTools`, `_admin_Marketing`, `_product_admin_Creative Cloud` or `_developer_Marketing`. You should avoid any logic that expects fixed group names as these are liable to change without notice. Organization-wide admin groups are:
-  * `_org_admin`: The user is a [System Administrator](glossary.md#orgAdmin).
-  * `_deployment_admin`: The user is a [Deployment Administrator](glossary.md#deployment).
-  * `_support_admin`: The user is a [Support Administator](glossary.md#supportAdmin).
-* __id:__ _string_; The user's unique identifier.
-* __lastname:__ _string_; The user's last name.
-{% include_relative partials/statusDescription.md %}
-* __type:__ _string_; The user type, one of: `{ "adobeID", "enterpriseID", "federatedID", "unknown" }`. See [Identity Types](glossary.md#identity) for more information.
-* __username:__ _string_; The user's username (applicable for [Enterprise](glossary.md#enterpriseId) and [Federated](glossary.md#federatedId) users). For most [AdobeID](glossary.md#adobeId) users, this value will be the same as the email address.
-* **adminRoles:** _string[]_; Deprecated. Administrative roles are reflected in group memberships, returned in the `groups` field.
+{% include_relative partials/userSchemaDescription.md %}
 
 ### Schema Model 
 
@@ -184,7 +174,10 @@ __users:__  Contains a list of _User_ objects. Properties that are not populated
       "lastname": "string",
       "status": "string",
       "type": "string",
-      "username": "string"
+      "username": "string",
+      "tags": [
+          "string"
+      ]
     }
   ]
 }

--- a/docs/en/api/partials/userSchemaDescription.md
+++ b/docs/en/api/partials/userSchemaDescription.md
@@ -11,5 +11,5 @@
 {% include_relative partials/statusDescription.md %}
 * __type:__ _string_, The user type, one of: `{ "adobeID", "enterpriseID", "federatedID", "unknown" }`. See [Identity Types](glossary.md#identity) for more information.
 * __username:__ _string_; The user's username (applicable for [Enterprise](glossary.md#enterpriseId) and [Federated](glossary.md#federatedId) users). For most [Adobe ID](glossary.md#adobeId) users, this value is the same as the email address.
-* __tags:__ _string[]; The list of user's tags, if applicable.
+* __tags:__ _string[]_; The list of user's tags, if applicable.
 * **adminRoles:** _string[]_; Deprecated. Administrative roles are reflected in group memberships, returned in the `groups` field.

--- a/docs/en/api/partials/userSchemaDescription.md
+++ b/docs/en/api/partials/userSchemaDescription.md
@@ -1,0 +1,15 @@
+* __country:__ _string_; A valid ISO 2-character country code.
+* __domain:__ _string_; The user's domain.
+* __email:__ _string_; The user's email address.
+* __firstname:__ _string_; The user's first name.
+* __groups:__ _string[]_; The list of groups in which the user is a current member, including, user groups, product profiles, product admin groups, and group-specific admin groups. Administrative groups are named with a prefix and the group name. For example, `_product_admin_Photoshop`, `_admin_DesignTools`, or `_developer_Marketing`. You should avoid any logic that expects fixed group names as these are liable to change without notice. Organization-wide admin groups are:
+  * `_org_admin`: The user is a [System Administrator](glossary.md#orgAdmin).
+  * `_deployment_admin`: The user is a [Deployment Administrator](glossary.md#deployment).
+  * `_support_admin`: The user is a [Support Administator](glossary.md#supportAdmin).
+* __id:__ _string_; The user's unique identifier.
+* __lastname:__ _string_; The user's last name.
+{% include_relative partials/statusDescription.md %}
+* __type:__ _string_, The user type, one of: `{ "adobeID", "enterpriseID", "federatedID", "unknown" }`. See [Identity Types](glossary.md#identity) for more information.
+* __username:__ _string_; The user's username (applicable for [Enterprise](glossary.md#enterpriseId) and [Federated](glossary.md#federatedId) users). For most [Adobe ID](glossary.md#adobeId) users, this value is the same as the email address.
+* __tags:__ _string[]; The list of user's tags, if applicable.
+* **adminRoles:** _string[]_; Deprecated. Administrative roles are reflected in group memberships, returned in the `groups` field.

--- a/docs/en/api/partials/userSchemaDescription.md
+++ b/docs/en/api/partials/userSchemaDescription.md
@@ -8,8 +8,12 @@
   * `_support_admin`: The user is a [Support Administator](glossary.md#supportAdmin).
 * __id:__ _string_; The user's unique identifier.
 * __lastname:__ _string_; The user's last name.
-{% include_relative partials/statusDescription.md %}
+* __status:__ _string_; A user's status with the organization. Only "active" users are returned by [Get User Information](getUser.html) and [Get Users in Organization](getUsersWithPage.html). One of the following: 
+  * "active": Normal status for a user account in good standing.
+  * "disabled": Disabled temporarily - user is not allowed to login, but is not removed.
+  * "locked": Disabled permanently - user is not allowed to login, but is not removed.
+  * "removed": The user account is being removed. 
 * __type:__ _string_, The user type, one of: `{ "adobeID", "enterpriseID", "federatedID", "unknown" }`. See [Identity Types](glossary.md#identity) for more information.
 * __username:__ _string_; The user's username (applicable for [Enterprise](glossary.md#enterpriseId) and [Federated](glossary.md#federatedId) users). For most [Adobe ID](glossary.md#adobeId) users, this value is the same as the email address.
-* __tags:__ _string[]_; The list of user's tags, if applicable.
+* __tags:__ _string[]_; Returns a list of the tags applied to a user e.g. `["edu_student", "edu_staff"]`. This will not be returned if the user has no tags.
 * **adminRoles:** _string[]_; Deprecated. Administrative roles are reflected in group memberships, returned in the `groups` field.

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -11,6 +11,8 @@ Welcome to the documentation center for User Management APIs from Adobe.
 
 News:  
 <div class="isa_info">
+<p>From July 25th 2023, a new tags property will be returned as part of a user's response. Documentation in the impacted APIs has been updated. If you ignore unknown fields then you should expect no impact from this change.</p>
+<hr class="api-ref-rule">
 <p>On May 9th, 2023, the <code>productName</code> will be updated to include a new structure to help distinguish multiple products with the same name. An example of the structure is <code>&lt;Product Name&gt; (&lt;a list of keywords&gt;)</code>. For ETLA customers with a <a href="https://helpx.adobe.com/uk/enterprise/using/single-app.html">Single App plan</a> (the plan which enables you to choose any one app from a set of available Creative Cloud applications) you may be returned a structure like <code>Photoshop (&lt;keyword1,Single App,keyword2&gt;)</code> where keyword1 and keyword2 could be optional.</p><p>As a result, any application directly accessing the User Management API which includes logic <strong>dependent on fixed product names</strong> will need to be updated. If you have not included fixed product names in the code, then this will not impact your connection to the User Management API. If you use the User Sync Tool, you should see no impact.</p>
 <p>If you rely on the name of the “product admin group” (e.g., <code>_product_admin_&lt;product name&gt;</code>) you will also be impacted and have to update your scripts.</p>
 <p>You should avoid any logic that expects fixed group names as these are liable to change without notice. We recommend using the Get Groups and Profiles API to fetch the latest group information.</p>

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -11,7 +11,13 @@ Welcome to the documentation center for User Management APIs from Adobe.
 
 News:  
 <div class="isa_info">
-<p>From July 25th 2023, a new tags property will be returned as part of a user's response. Documentation in the impacted APIs has been updated. If you ignore unknown fields then you should expect no impact from this change.</p>
+<p>From July 25th 2023, a new tags property will be returned as part of a user's response in the following APIs:</p>
+	<ul>
+		<li><a href="api/getUser.html">Get User Information</a></li>
+		<li><a href="api/getUsersWithPage.html">Get Users in Organization</a></li>
+		<li><a href="api/getUsersByGroup.html">Get Users by Group</a></li>
+	</ul>
+<p>Further information can be found within the API documentation. If you ignore unknown fields then you should expect no impact from this change.</p>
 <hr class="api-ref-rule">
 <p>On May 9th, 2023, the <code>productName</code> will be updated to include a new structure to help distinguish multiple products with the same name. An example of the structure is <code>&lt;Product Name&gt; (&lt;a list of keywords&gt;)</code>. For ETLA customers with a <a href="https://helpx.adobe.com/uk/enterprise/using/single-app.html">Single App plan</a> (the plan which enables you to choose any one app from a set of available Creative Cloud applications) you may be returned a structure like <code>Photoshop (&lt;keyword1,Single App,keyword2&gt;)</code> where keyword1 and keyword2 could be optional.</p><p>As a result, any application directly accessing the User Management API which includes logic <strong>dependent on fixed product names</strong> will need to be updated. If you have not included fixed product names in the code, then this will not impact your connection to the User Management API. If you use the User Sync Tool, you should see no impact.</p>
 <p>If you rely on the name of the “product admin group” (e.g., <code>_product_admin_&lt;product name&gt;</code>) you will also be impacted and have to update your scripts.</p>

--- a/docs/en/samples/index.md
+++ b/docs/en/samples/index.md
@@ -27,9 +27,9 @@ A Postman collection is also available at the bottom of the page.
 | [get_users_in_org.py]({{ site.github_url }}/blob/master/samples/get_users_in_org.py) | Retrieve information about all accounts in for your organization. |
 | [get_users_by_group.py]({{ site.github_url }}/blob/master/samples/get_users_by_group.py) | Retrieve members list of a specified group. |
 | [get_user_info.py]({{ site.github_url }}/blob/master/samples/get_user_info.py) | Retrieve details on a specific account.|
-| [remove_account.py]({{ site.github_url }}/blob/master/samples/RemoveFromOrg.py) | Soft or hard removal of an account from the Organization. |
-| [multi_action.py]({{ site.github_url }}/blob/master/samples/UserMultipleOperations.py) | Demo multi action request |
-| [source.csv]({{ site.github_url }}/blob/master/samples/UserMultipleOperations.py) | Sample csv file for the multi_action.py script. |
+| [remove_account.py]({{ site.github_url }}/blob/master/samples/remove_account.py) | Soft or hard removal of an account from the Organization. |
+| [multi_action.py]({{ site.github_url }}/blob/master/samples/multi_action.py) | Demo multi action request |
+| [source.csv]({{ site.github_url }}/blob/master/samples/source.csv) | Sample csv file for the multi_action.py script. |
 {:.bordertablestyle}  
 
 ***


### PR DESCRIPTION
From 25th July 2023, User Management will start to return a `tags` array for users that have had any EDU related tags applied to their account. Users that do not have any tags will not have this new field returned.
This PR adds:
- a general announcement
- updates the following three APIs to include `tags` within the documentation with examples
- moves the user schema description to its own partial as it is repeated in numerous sections

Impacted APIs:
```
GET /v2/usermanagement/organizations/{orgId}/users/{userString}
GET /v2/usermanagement/users/{orgId}/{page}
GET /v2/usermanagement/users/{orgId}/{page}/{groupName}
```