### PR TITLE
Remove out of date advice message from deprecated APIs 

### DIFF
--- a/docs/en/api/QueryProducts.md
+++ b/docs/en/api/QueryProducts.md
@@ -8,7 +8,7 @@ title: Product Access APIs
 ---
 # <a name="productApis" class="api-ref-title">Product Access APIs</a>
 
-**DEPRECATED:** These APIs have been deprecated. An exact date for removal will be confirmed before the end of 2017 but you should look to update your scripts as soon as possible.
+**DEPRECATED:** These APIs have been deprecated. Please use [Get User Groups and Product Profiles](group.md).
 
 <hr class="api-ref-rule">
 

--- a/docs/en/api/QueryUserGroups.md
+++ b/docs/en/api/QueryUserGroups.md
@@ -8,7 +8,7 @@ title: Get User Group Users
 ---
 # <a name="queryUserGroups" class="api-ref-title">Get User-group Users</a>
 
-**DEPRECATED:** These APIs have been deprecated. An exact date for removal will be confirmed before the end of 2017 but you should look to update your scripts as soon as possible.
+**DEPRECATED:** These APIs have been deprecated. Please use [Get Users by Group API](getUsersByGroup.md) for fetching information for a single group.
 
 <hr class="api-ref-rule">
 

--- a/docs/en/api/getAllProfilesForOrg.md
+++ b/docs/en/api/getAllProfilesForOrg.md
@@ -9,7 +9,7 @@ nav_link: Get All Profiles
 
 # <a name="getAllProfiles" class="api-ref-title">Get All Product Profiles for Organization</a>
 
-**DEPRECATED:** These APIs have been deprecated. An exact date for removal will be confirmed before the end of 2017 but you should look to update your scripts as soon as possible.
+**DEPRECATED:** These APIs have been deprecated. Please use [Get User Groups and Product Profiles](group.md).
 
 <hr class="api-ref-rule">
 

--- a/docs/en/api/getProductProfile.md
+++ b/docs/en/api/getProductProfile.md
@@ -8,7 +8,7 @@ lang: en
 ---
 # <a name="getProfile" class="api-ref-title">Get Product Profile</a>
 
-**DEPRECATED:** These APIs have been deprecated. An exact date for removal will be confirmed before the end of 2017 but you should look to update your scripts as soon as possible.
+**DEPRECATED:** These APIs have been deprecated. Please use [Get Users by Group API](getUsersByGroup.md) for fetching information for a single product profile.
 
 <hr class="api-ref-rule">
 ```

--- a/docs/en/api/getProductProfileUsers.md
+++ b/docs/en/api/getProductProfileUsers.md
@@ -8,7 +8,7 @@ lang: en
 ---
 # <a name="getProfileUsers" class="api-ref-title">Get Users in Product Profile</a>
 
-**DEPRECATED:** These APIs have been deprecated. An exact date for removal will be confirmed before the end of 2017 but you should look to update your scripts as soon as possible.
+**DEPRECATED:** These APIs have been deprecated. Please use [Get Users by Group API](getUsersByGroup.md) for fetching users of a product profile.
 
 <hr class="api-ref-rule">
 

--- a/docs/en/api/getUserGroup.md
+++ b/docs/en/api/getUserGroup.md
@@ -9,7 +9,7 @@ lang: en
 
 # <a name="getUserGroup" class="api-ref-title">Get User Group</a>
 
-**DEPRECATED:** These APIs have been deprecated. An exact date for removal will be confirmed before the end of 2017 but you should look to update your scripts as soon as possible.
+**DEPRECATED:** These APIs have been deprecated. Please use [Get Users by Group API](getUsersByGroup.md) for fetching information for a single group.
 
 <hr class="api-ref-rule">
 

--- a/docs/en/api/getUserGroups.md
+++ b/docs/en/api/getUserGroups.md
@@ -8,7 +8,7 @@ lang: en
 ---
 # <a name="getUserGroups" class="api-ref-title">Get User Groups</a>
 
-**DEPRECATED:** These APIs have been deprecated. An exact date for removal will be confirmed before the end of 2017 but you should look to update your scripts as soon as possible.
+**DEPRECATED:** These APIs have been deprecated. Please use [Get User Groups and Product Profiles](group.md).
 
 <hr class="api-ref-rule">
 

--- a/docs/en/api/getUsersREST.md
+++ b/docs/en/api/getUsersREST.md
@@ -9,7 +9,7 @@ lang: en
 
 # <a name="getUsersWithPage" class="api-ref-title">Get All Users in Organization</a>
 
-**DEPRECATED:** These APIs have been deprecated. An exact date for removal will be confirmed before the end of 2017 but you should look to update your scripts as soon as possible.
+**DEPRECATED:** These APIs have been deprecated. Please use [Get Users in Organization](getUsersWithPage.md)
 
 <hr class="api-ref-rule">
 

--- a/docs/en/api/updateProductProfile.md
+++ b/docs/en/api/updateProductProfile.md
@@ -8,7 +8,7 @@ lang: en
 ---
 # <a name="updateProfile" class="api-ref-title">Update Product Profile</a>
 
-**DEPRECATED:** These APIs have been deprecated. An exact date for removal will be confirmed before the end of 2017 but you should look to update your scripts as soon as possible.
+**DEPRECATED:** These APIs have been deprecated. Please refer to the [User Management Action API](ActionsRef.md) for details on the supported approach to assign and manage membership and administrative rights within your Organization.
 
 <hr class="api-ref-rule">
 


### PR DESCRIPTION
Updating the deprecated banner to remove the old 2017 messaging.
Instead I have added links to the supported UMAPI workflows.