### PR TITLE
Add documentation for excludeGroups query parameter

### DIFF
--- a/docs/en/api/getUsersByGroup.md
+++ b/docs/en/api/getUsersByGroup.md
@@ -36,7 +36,7 @@ __Throttle Limits__: Maximum 25 requests per minute per a client. See [Throttlin
 | X-Request-Id | header | false | {% include_relative partials/requestIdDescription.md %} |
 | directOnly | query | false | {% include_relative partials/directOnlyDescription.md %} |
 | status | query | false | For product profiles only, return only active or inactive members. Pass `active` to list users that have been provisioned for the product and have an active license. Pass `inactive` to list users who have been added to the product profile but do not have an _active_ license. When not provided, lists all member users regardless of their entitlement status.|
-| excludeGroups | query | false | Default value is false. When true is passed the response will exclude the `groups` array from being returned for each individual user. See [example](#getUsersWithNoGroupsExample). |
+| excludeGroups | query | false | Default value is `false`. When `true` is passed the response will exclude the `groups` array from being returned for each individual user. See [example](#getUsersWithNoGroupsExample). |
 {:.bordertablestyle}
 
 ## <a name="responses" class="api-ref-subtitle">Responses</a>

--- a/docs/en/api/getUsersByGroup.md
+++ b/docs/en/api/getUsersByGroup.md
@@ -36,6 +36,7 @@ __Throttle Limits__: Maximum 25 requests per minute per a client. See [Throttlin
 | X-Request-Id | header | false | {% include_relative partials/requestIdDescription.md %} |
 | directOnly | query | false | {% include_relative partials/directOnlyDescription.md %} |
 | status | query | false | For product profiles only, return only active or inactive members. Pass `active` to list users that have been provisioned for the product and have an active license. Pass `inactive` to list users who have been added to the product profile but do not have an _active_ license. When not provided, lists all member users regardless of their entitlement status.|
+| excludeGroups | query | false | Default value is false. When true is passed the response will exclude the `groups` array from being returned for each individual user. See [example](#getUsersWithNoGroupsExample). |
 {:.bordertablestyle}
 
 ## <a name="responses" class="api-ref-subtitle">Responses</a>
@@ -108,6 +109,46 @@ A successful request returns a response body with the requested user data in JSO
                 "Document Cloud 1",
                 "Creative Cloud 1"
             ],
+            "username": "bob",
+            "domain": "example.com",
+            "country": "US",
+            "type": "federatedID"
+        }
+        ...
+      ]
+}
+```
+
+<a name="getUsersWithNoGroupsExample" class="api-ref-subtitle">Response returning three members of the Document Cloud 1 group. The `groups` array for each user has been excluded in the response as the query parameter `excludeGroups=true` was included:</a>
+
+```json
+{
+    "lastPage": false,
+    "result": "success",
+    "groupName": "Document Cloud 1",
+    "users": [
+        {
+            "email": "john@example.com",
+            "status": "active",
+            "username": "john",
+            "domain": "example.com",
+            "country": "US",
+            "type": "federatedID",
+            "tags": [
+                "edu_student"
+            ]
+        },
+        {
+            "email": "jane@example.com",
+            "status": "active",
+            "username": "jane",
+            "domain": "example.com",
+            "country": "US",
+            "type": "federatedID"
+        },
+        {
+            "email": "bob@example.com",
+            "status": "active",
             "username": "bob",
             "domain": "example.com",
             "country": "US",

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -11,6 +11,10 @@ Welcome to the documentation center for User Management APIs from Adobe.
 
 News:  
 <div class="isa_info">
+<p>From Jan 16th 2024, a new query parameter <code>excludeGroups</code> will be available in <a href="api/getUsersByGroup.html">Get Users by Group</a> to exclude the return of other group membership information for each user.</p>
+<p>Further information and examples can be found within the API documentation.</p>
+<p>This does not impact existing clients.</p>
+<hr class="api-ref-rule">
 <p>From July 25th 2023, a new tags property will be returned as part of a user's response in the following APIs:</p>
 	<ul>
 		<li><a href="api/getUser.html">Get User Information</a></li>


### PR DESCRIPTION
Introducing a new query parameter to API `GET /v2/usermanagement/users/{orgId}/{page}/{groupName}` so that clients can exclude the return of the users' group membership details.
Before:
```
{
    "lastPage": false,
    "result": "success",
    "groupName": "Document Cloud 1",
    "users": [
        {
            "email": "john@example.com",
            "status": "active",
            "groups": [
                "Document Cloud 1"
            ],
            "username": "john",
            "domain": "example.com",
            "country": "US",
            "type": "federatedID",
            "tags": [
                "edu_student"
            ]
        },
        {
            "email": "jane@example.com",
            "status": "active",
            "groups": [
                "Document Cloud 1",
                "Support for AEM Mobile",
                "_admin_Document Cloud 1",
                "_admin_Support for AEM Mobile",
                "_admin_Default Support profile",
                "_admin_Creative Cloud 1",
                "_deployment_admin",
                "_developer_Document Cloud 1"
            ],
            "username": "jane",
            "domain": "example.com",
            "country": "US",
            "type": "federatedID"
        },
        {
            "email": "bob@example.com",
            "status": "active",
            "groups": [
                "Document Cloud 1",
                "Creative Cloud 1"
            ],
            "username": "bob",
            "domain": "example.com",
            "country": "US",
            "type": "federatedID"
        }
      ]
}
```
Passing `excludeGroups=true`:
```
{
    "lastPage": false,
    "result": "success",
    "groupName": "Document Cloud 1",
    "users": [
        {
            "email": "john@example.com",
            "status": "active",
            "username": "john",
            "domain": "example.com",
            "country": "US",
            "type": "federatedID",
            "tags": [
                "edu_student"
            ]
        },
        {
            "email": "jane@example.com",
            "status": "active",
            "username": "jane",
            "domain": "example.com",
            "country": "US",
            "type": "federatedID"
        },
        {
            "email": "bob@example.com",
            "status": "active",
            "username": "bob",
            "domain": "example.com",
            "country": "US",
            "type": "federatedID"
        }
      ]
}
```