### PR TITLE
Announcement for deprecation and removal of tags

### DIFF
--- a/docs/en/api/getUser.md
+++ b/docs/en/api/getUser.md
@@ -72,6 +72,9 @@ The response body contains the requested user data in JSON format including any 
   }
 }
 ```
+
+:warning: As of October 16, 2025, the `tags` array will no longer be returned.
+
 <a name="getUserGroupsExample" class="api-ref-subtitle">[Enterprise](glossary.md#enterpriseId) User with membership</a> in two user-groups but no administrative roles. If the fields are not populated (`firstname` and`lastname` in this example), they are excluded from the response.
 ```json
 {
@@ -147,6 +150,8 @@ __user:__  A _user_ object containing relevant properties. Properties that are n
   }
 }
 ```
+
+:warning: As of October 16, 2025, the `tags` array will no longer be returned.
 
 {% include_relative partials/badRequest.md anchor="400getUser" %}
 

--- a/docs/en/api/getUsersByGroup.md
+++ b/docs/en/api/getUsersByGroup.md
@@ -119,6 +119,8 @@ A successful request returns a response body with the requested user data in JSO
 }
 ```
 
+:warning: As of October 16, 2025, the `tags` array will no longer be returned.
+
 <a name="getUsersWithNoGroupsExample" class="api-ref-subtitle">Response returning three members of the Document Cloud 1 group. The `groups` array for each user has been excluded in the response as the query parameter `excludeGroups=true` was included:</a>
 
 ```json
@@ -158,6 +160,8 @@ A successful request returns a response body with the requested user data in JSO
       ]
 }
 ```
+
+:warning: As of October 16, 2025, the `tags` array will no longer be returned.
 
 <a name="getUsersExampleLastPage" class="api-ref-subtitle">Response to request for the last page:
 
@@ -227,6 +231,8 @@ __users:__  Contains a list of _User_ objects. Properties that are not populated
   ]
 }
 ```
+
+:warning: As of October 16, 2025, the `tags` array will no longer be returned.
 
 {% include_relative partials/badRequest.md anchor="400getUsersByGroup" %}
 

--- a/docs/en/api/getUsersWithPage.md
+++ b/docs/en/api/getUsersWithPage.md
@@ -120,6 +120,8 @@ A successful request returns a response body with the requested user data in JSO
     ]
 }
 ```
+:warning: As of October 16, 2025, the `tags` array will no longer be returned.
+
 <a name="getUsersExampleLastPage" class="api-ref-subtitle">Response that is the last page:
 ```json
 {
@@ -182,6 +184,8 @@ __users:__  Contains a list of _User_ objects. Properties that are not populated
   ]
 }
 ```
+
+:warning: As of October 16, 2025, the `tags` array will no longer be returned.
 
 {% include_relative partials/badRequest.md anchor="400getUsersWithPage" %}
 

--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -11,6 +11,14 @@ Welcome to the documentation center for User Management APIs from Adobe.
 
 <h2>News</h2>
 <div class="isa_info">
+<p>April 15, 2025: As of 16 October, 2025, UMAPI will no longer return "tags" information as documented for the following APIs:</p>
+	<ul>
+		<li><a href="api/getUser.html">Get User Information</a></li>
+		<li><a href="api/getUsersWithPage.html">Get Users in Organization</a></li>
+		<li><a href="api/getUsersByGroup.html">Get Users by Group</a></li>
+	</ul>
+<p>Note that this data is likely to become stale over the coming months as the attribute is deprecated internally. If you are currently using this information, please get in touch with the developer support team to let us know your use case. Note that as this change is due to the data being retired from the Adobe platform, UMAPI will not be able to offer extensions to this time frame.</p>
+<hr class="api-ref-rule">
 <p>July 22, 2024: To provide peace of mind for API integrations, all APIs provided by UMAPI, even those marked as deprecated will continue to be supported for the foreseeable future.</p>
 <p>If it becomes apparent that any API, deprecated or otherwise, needs to be retired from service or needs updated with a breaking change, Adobe will provide at least 6 (six) months notice of the change, via UMAPI documentation (this site) and via Developer Console banners.</p>
 <p>We will also endeavour to provide 4 weeks notice of any new fields that are being added to responses in order to give time to prepare. As ever, guidance is to ignore any unrecognised or unknown fields in the UMAPI response. Unless it is documented, it should not be relied upon.</p>


### PR DESCRIPTION
As of 16 October, 2025, UMAPI will no longer return "tags" information as documented for the following APIs:

* [Get User Information](https://adobe-apiplatform.github.io/umapi-documentation/en/api/getUser.html)
* [Get Users in Organization](https://adobe-apiplatform.github.io/umapi-documentation/en/api/getUsersWithPage.html)
* [Get Users by Group](https://adobe-apiplatform.github.io/umapi-documentation/en/api/getUsersByGroup.html)

Note that this data is likely to become stale over the coming months as the attribute is deprecated internally. If you are currently using this information, please get in touch with the developer support team to let us know your use case. Note that as this change is due to the data being retired from the Adobe platform, UMAPI will not be able to offer extensions to this time frame.